### PR TITLE
new API for gene_families service

### DIFF
--- a/KBaseGeneFamilies.spec
+++ b/KBaseGeneFamilies.spec
@@ -154,11 +154,12 @@ module KBaseGeneFamilies {
 
 	/* 
 		@id ws KBaseGeneFamilies.DomainAlignments
-	*/
 	typedef string domain_alignments_ref;
+	*/
 
 	/*
 		genome_ref genome_ref - reference to genome
+		dms_ref used_dms_ref - domain models used for search
 		mapping<contig_id, list<annotation_element>> data - 
 			list of entrances of different domains into proteins of annotated genome
 			(annotation_element -> typedef tuple<string feature_id,int feature_start,int feature_stop,
@@ -169,16 +170,14 @@ module KBaseGeneFamilies {
 			feature count and nucleotide size of every contig
 		mapping<string feature_id, tuple<contig_id,int feature_index> feature_to_contig_and_index - 
 			index of every feature in feature list in every contig
-		domain_alignments_ref alignments_ref - reference to alignments of protein sequences against 
-			domain profiles
-		@optional alignments_ref
 	*/
 	typedef structure {
 		genome_ref genome_ref;
+		dms_ref used_dms_ref;
 		mapping<contig_id, list<annotation_element>> data;
 		mapping<contig_id, tuple<int size,int features>> contig_to_size_and_feature_count;
 		mapping<string feature_id, tuple<contig_id,int feature_index>> feature_to_contig_and_index;
-		domain_alignments_ref alignments_ref; 
+		/* domain_alignments_ref alignments_ref; */
 	} DomainAnnotation;
 
 	/*
@@ -292,8 +291,10 @@ module KBaseGeneFamilies {
 		string out_result_id;
 	} SearchDomainsParams;
 	
-	funcdef search_domains(SearchDomainsParams params) returns (string job_id) authentication 
-		required;
+	funcdef search_domains(SearchDomainsParams params) returns (string job_id) authentication required;
+
+	/* returns version number of service */
+	funcdef version() returns (string version);
 
 	/*
 		list<domain_annotation_ref> genome_annotations - annotated genome list

--- a/KBaseGeneFamilies.spec
+++ b/KBaseGeneFamilies.spec
@@ -101,23 +101,28 @@ module KBaseGeneFamilies {
 
 	/* 
 		@id ws KBaseGeneFamilies.DomainCluster
-	*/
 	typedef string domain_cluster_ref;
+	*/
 
 	typedef tuple<int start_in_feature,int stop_in_feature,float evalue,
 		float bitscore, float domain_coverage> domain_place;
 
+/*
 	typedef tuple<string contig_id,string feature_id,int feature_index,
 		list<domain_place>> domain_cluster_element;
+*/
 
-	/* @id ws KBaseTrees.MSA */
+	/* @id ws KBaseTrees.MSA
 	typedef string ws_alignment_id;
+ */
 
-	/* @id ws KBaseTrees.MSASet */
+	/* @id ws KBaseTrees.MSASet
 	typedef string msa_set_ref;
+ */
 
-	/* @id ws KBaseTrees.Tree */
+	/* @id ws KBaseTrees.Tree
 	typedef string ws_tree_id;
+ */
 
 	/*
 		domain_accession model - reference to domain model
@@ -134,13 +139,13 @@ module KBaseGeneFamilies {
 			DomainClusterSearchResult object instead.
 		@optional parent_ref
 		@optional msa_ref
-	*/
 	typedef structure {
 		domain_accession model;
 		domain_cluster_ref parent_ref;
 		mapping<genome_ref,list<domain_cluster_element>> data;
 		ws_alignment_id msa_ref;
 	} DomainCluster;
+	*/
 
 	typedef tuple<string feature_id,int feature_start,int feature_stop,int feature_dir,
 		mapping<domain_accession,list<domain_place>>> annotation_element;
@@ -183,12 +188,12 @@ module KBaseGeneFamilies {
 			mapping from start position of alignment in feature sequence to aligned sequence of 
 			domain occurrence (mapping<domain_accession, mapping<string feature_id,
 				mapping<string start_in_feature, string alignment_with_profile>>>).
-	*/
 	typedef structure {
 		genome_ref genome_ref;
 		mapping<domain_accession,mapping<string feature_id,
 			mapping<string start_in_feature,string alignment_with_profile>>> alignments; 
 	} DomainAlignments;
+	*/
 
 	/* 
 		@id ws KBaseGeneFamilies.DomainAnnotation
@@ -197,12 +202,11 @@ module KBaseGeneFamilies {
 
 	/* 
 		@id ws KBaseGeneFamilies.DomainClusterSearchResult
-	*/
 	typedef string dcsr_ref;
+	*/
 
 	/*
-		Aggreagated data for every genome.
-	*/
+		Aggregated data for every genome.
 	typedef structure {
 		genome_ref genome_ref;
 		string kbase_id;
@@ -212,10 +216,10 @@ module KBaseGeneFamilies {
 		int domain_models;
 		int domains;
 	} GenomeStat;
+	*/
 
 	/*
 		Aggregated data for every domain cluster.
-	*/
 	typedef structure {
 		domain_accession domain_accession;
 		string name;
@@ -223,6 +227,7 @@ module KBaseGeneFamilies {
 		int features;
 		int domains;
 	} DomainClusterStat;	
+	*/
 
 	/*
 		dcsr_ref parent_ref - optional reference to parent domain clusters search results
@@ -257,7 +262,6 @@ module KBaseGeneFamilies {
 		@optional msa_refs
 		@optional trees
 		@optional tree_refs
-	*/
 	typedef structure {
 		dcsr_ref parent_ref;
 		dms_ref used_dms_ref;
@@ -273,6 +277,7 @@ module KBaseGeneFamilies {
 		mapping<domain_accession, KBaseTrees.Tree> trees;
 		mapping<domain_accession, ws_tree_id> tree_refs;
 	} DomainClusterSearchResult;
+	*/
 
 	/*
 		genome_ref genome - genome for domain annotation process

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ deploy-scripts:
 	@echo "No deployment for scripts"
 
 deploy-docs:
-	$(ANT) docs
+	$(ANT) javadoc
 	rsync -a ./docs $(SERVICE_DIR)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ download-thirdparty-bins:
 prepare-thirdparty-dbs:	download-thirdparty-bins
 	./prepare_3rd_party_dbs.sh
 
+prepare-library-objects: prepare-thirdparty-dbs compile
+	java -jar dist/($SERVICE_NAME).jar
+
 prepare-deploy-target:	prepare-thirdparty-dbs
 
 deploy-client:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GLASSFISH_HOME ?= $(DEPLOY_RUNTIME)/glassfish3
 ASADMIN = $(GLASSFISH_HOME)/glassfish/bin/asadmin
 ANT = ant
 
-default: compile
+default: compile build-docs
 
 deploy-all: deploy
 
@@ -27,19 +27,39 @@ test: test-all
 test-all: test-java
 
 test-client:
-	@echo "No tests for client"
+	@echo "All tests are in java; make test-java"
 
 test-service:
-	@echo "No tests for service yet"
+	@echo "All tests are in java; make test-java"
 
 test-scripts:
-	@echo "No tests for scripts"
+	@echo "No scripts"
 
 test-java:  prepare-thirdparty-dbs
 	$(ANT) test
 
 compile: src
 	$(ANT) war
+
+setup-lib-dir:
+	mkdir -p lib/biokbase/$(SERVICE_NAME)
+	mkdir -p lib/javascript/$(SERVICE_NAME)
+
+compile-typespec: setup-lib-dir
+	compile_typespec \
+		--client Bio::KBase::$(SERVICE_NAME)::Client \
+		--py biokbase/$(SERVICE_NAME)/Client \
+		--js javascript/$(SERVICE_NAME)/Client \
+		--url https://kbase.us/services/gene_families \
+		$(SERVICE_NAME).spec lib
+	rm -f lib/$(SERVICE_NAME)*.py
+	rm -f lib/$(SERVICE_NAME)*.pm
+
+build-docs: compile-typespec
+	mkdir -p docs
+	pod2html --infile=lib/Bio/KBase/$(SERVICE_NAME)/Client.pm --outfile=docs/$(SERVICE_NAME).html
+	rm -f pod2htmd.tmp
+	$(ANT) javadoc
 
 src: KBaseGeneFamilies.spec
 	./generate_java_classes.sh

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,0 +1,16 @@
+OVERVIEW
+-----------------------------------------
+This KBase service provides methods for finding (protein) domains in
+genomes.
+
+
+VERSION: 0.01 (Released 1/13/2015)
+------------------------------------------
+NEW FEATURES:
+-This is the first internal release of the GeneFamilies Service, all methods are new.
+
+UPDATED FEATURES / MAJOR BUG FIXES:
+-none.
+
+ANTICIPATED FUTURE DEVELOPMENTS:
+-public release of the service

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -4,13 +4,10 @@ This KBase service provides methods for finding (protein) domains in
 genomes.
 
 
-VERSION: 0.01 (Released 1/13/2015)
+VERSION: 1.0.0 (Released 1/14/2015)
 ------------------------------------------
 NEW FEATURES:
--This is the first internal release of the GeneFamilies Service, all methods are new.
+-This is the first public release of the GeneFamilies Service, all methods are new.
 
 UPDATED FEATURES / MAJOR BUG FIXES:
 -none.
-
-ANTICIPATED FUTURE DEVELOPMENTS:
--public release of the service

--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,7 @@
   <property name="war.file" value="KBaseGeneFamilies.war"/>
   <property name="war" value="war"/>
   <property name="war.lib" value="${war}/lib"/>
-  <property name="docs" value="docs"/>
+  <property name="docs" value="docs/javadoc"/>
   <property name="jarsdir" value="../jars/lib/jars"/>
   <property name="bindir" value="data/bin/"/>
   <property name="deploycfg" value=""/>
@@ -104,8 +104,16 @@
     <delete dir="${war}"/>
   </target>
 
-  <target name="docs" description="prepare documentation">
-    <mkdir dir="${docs}"/>
+  <target name="javadoc" description="build javadocs">
+    <javadoc access="protected" author="false" classpathref="compile.classpath"
+      destdir="${docs}" nodeprecated="false" nodeprecatedlist="false"
+      noindex="false" nonavbar="false" notree="false"
+      source="1.7" splitindex="true" use="true" version="true"
+      packagenames="us.kbase.kbasegenefamilies.*" sourcepath="${src}">
+      <link href="http://download.oracle.com/javase/7/docs/api/"/>
+      <link href="http://fasterxml.github.io/jackson-core/javadoc/2.2.0/"/>
+      <link href="http://fasterxml.github.io/jackson-databind/javadoc/2.2.0/"/>
+    </javadoc>
   </target>
 
   <target name="preparejunitreportdir" if="env.JENKINS_REPORT_DIR">

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -1,7 +1,7 @@
 [gene_families]
 scratch=/mnt/gene_families
-#workspace.srv.url=https://kbase.us/services/ws
-workspace.srv.url=http://dev04.berkeley.kbase.us:7058
+workspace.srv.url=https://kbase.us/services/ws
+# workspace.srv.url=http://dev04.berkeley.kbase.us:7058
 jobstatus.srv.url=https://kbase.us/services/userandjobstate/
 queue.db.dir=/mnt/gene_families/queue
 ###

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,24 @@
-gene_families repo
+The Gene Families service finds domains (from public protein domain
+libraries such as COGs and Pfam) in proteins in a user-supplied
+genome.
+
+It requires binaries from HMMER and RPS-BLAST, which are retrieved
+using the "download_3rd_party_bins.sh" script, and stored in the
+JAR file.  This is done automatically as part of the "make" process.
+
+It requires several public PSSM and HMM libraries, which are retrieved
+using the "prepare_3rd_party_dbs.sh" script.  The script also formats
+the libraries for use by HMMER or RPS-BLAST.  This is done
+automatically as part of the "make" process.
+
+The libraries have to be parsed and stored in DomainModelSet objects
+in a public KBase workspace called "KBasePublicGeneDomains."  This
+needs to be done once every time a new version of the libraries is
+desired.  The code to do this is in
+us.kbase.kbasegenefamilies.prepare.DomainModelLibPreparation
+and needs to be run by a developer with write access to that workspace.
+(A token needs to be stored in auth.properties to grant this access.)
+Once the libraries are downloaded using the script above, the
+developer needs to run "make prepare_library_objects"
+
+

--- a/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
+++ b/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
@@ -38,8 +38,7 @@ public class KBaseGeneFamiliesServer extends JsonServerServlet {
     private static TaskQueue taskHolder = null;
     private static TaskQueueConfig taskConfig = null;
     
-	private static final String defaultWsUrl = "http://dev04.berkeley.kbase.us:7058";
-	//private static final String defaultWsUrl = "https://kbase.us/services/ws/";
+    private static final String defaultWsUrl = "https://kbase.us/services/ws/";
     private static final String defaultUjsUrl = "https://kbase.us/services/userandjobstate/";
     
     public static final String SYS_PROP_KB_DEPLOYMENT_CONFIG = "KB_DEPLOYMENT_CONFIG";

--- a/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
+++ b/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
@@ -157,38 +157,6 @@ public class KBaseGeneFamiliesServer extends JsonServerServlet {
         return returnVal;
     }
 
-    /**
-     * <p>Original spec-file function name: construct_domain_clusters</p>
-     * <pre>
-     * </pre>
-     * @param   params   instance of type {@link us.kbase.kbasegenefamilies.ConstructDomainClustersParams ConstructDomainClustersParams}
-     * @return   parameter "job_id" of String
-     */
-    @JsonServerMethod(rpc = "KBaseGeneFamilies.construct_domain_clusters")
-    public String constructDomainClusters(ConstructDomainClustersParams params, AuthToken authPart) throws Exception {
-        String returnVal = null;
-        //BEGIN construct_domain_clusters
-        returnVal = getTaskQueue().addTask(params, authPart.toString());
-        //END construct_domain_clusters
-        return returnVal;
-    }
-
-    /**
-     * <p>Original spec-file function name: search_domains_and_construct_clusters</p>
-     * <pre>
-     * </pre>
-     * @param   params   instance of type {@link us.kbase.kbasegenefamilies.SearchDomainsAndConstructClustersParams SearchDomainsAndConstructClustersParams}
-     * @return   parameter "job_id" of String
-     */
-    @JsonServerMethod(rpc = "KBaseGeneFamilies.search_domains_and_construct_clusters")
-    public String searchDomainsAndConstructClusters(SearchDomainsAndConstructClustersParams params, AuthToken authPart) throws Exception {
-        String returnVal = null;
-        //BEGIN search_domains_and_construct_clusters
-        returnVal = getTaskQueue().addTask(params, authPart.toString());
-        //END search_domains_and_construct_clusters
-        return returnVal;
-    }
-
     public static void main(String[] args) throws Exception {
         if (args.length != 1) {
             System.out.println("Usage: <program> <server_port>");

--- a/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
+++ b/src/us/kbase/kbasegenefamilies/KBaseGeneFamiliesServer.java
@@ -50,7 +50,7 @@ public class KBaseGeneFamiliesServer extends JsonServerServlet {
     public static final String CFG_PROP_TEMP_DIR = "scratch";
     public static final String CFG_PROP_DATA_DIR = "data.dir";
     
-    public static final String SERVICE_VERSION = "1.0";
+    public static final String SERVICE_VERSION = "1.0.0";
     public static final String SERVICE_DEPLOYMENT_NAME = "gene_families";
     public static final String SERVICE_REGISTERED_NAME = "KBaseGeneFamilies";
 
@@ -153,6 +153,22 @@ public class KBaseGeneFamiliesServer extends JsonServerServlet {
         //BEGIN search_domains
         returnVal = getTaskQueue().addTask(params, authPart.toString());
         //END search_domains
+        return returnVal;
+    }
+
+    /**
+     * <p>Original spec-file function name: version</p>
+     * <pre>
+     * returns version number of service
+     * </pre>
+     * @return   parameter "version" of String
+     */
+    @JsonServerMethod(rpc = "KBaseGeneFamilies.version")
+    public String version() throws Exception {
+        String returnVal = null;
+        //BEGIN version
+	returnVal = SERVICE_VERSION;
+        //END version
         return returnVal;
     }
 

--- a/src/us/kbase/kbasegenefamilies/SearchDomainsBuilder.java
+++ b/src/us/kbase/kbasegenefamilies/SearchDomainsBuilder.java
@@ -38,35 +38,22 @@ public class SearchDomainsBuilder extends DefaultTaskBuilder<SearchDomainsParams
 	public void run(String token, SearchDomainsParams inputData, String jobId,
 			String outRef) throws Exception {
 	DomainSearchTask dst = new DomainSearchTask(tempDir, storage);
-	Tuple2<DomainAnnotation, DomainAlignments> res = dst.runDomainSearch(
-									     token, inputData.getDmsRef(), inputData.getGenome());
-	saveResult(inputData.getOutWorkspace(), inputData.getOutResultId(), token, res.getE1(), res.getE2(), inputData);
+	DomainAnnotation res = dst.runDomainSearch(token, inputData.getDmsRef(), inputData.getGenome());
+	saveResult(inputData.getOutWorkspace(), inputData.getOutResultId(), token, res, inputData);
     }
 	
     private void saveResult(String ws, String id, String token, DomainAnnotation annRes, 
-			    DomainAlignments alnRes, SearchDomainsParams inputData) throws Exception {
-	saveAnnotation(storage, token, ws, id, annRes, alnRes, inputData.getGenome(), inputData, "construct_multiple_alignment");
+			    SearchDomainsParams inputData) throws Exception {
+	saveAnnotation(storage, token, ws, id, annRes, inputData.getGenome(), inputData, "construct_multiple_alignment");
     }
 	
     public static String saveAnnotation(ObjectStorage storage, String token, String ws, String id, 
-					DomainAnnotation annRes, DomainAlignments alnRes, String genomeRef, 
+					DomainAnnotation annRes, String genomeRef, 
 					Object inputData, String serviceMethod) throws Exception {
-	String alignmentsRef = DomainSearchTask.getRefFromObjectInfo(
-								     storage.saveObjects(token,
-											 new SaveObjectsParams().withWorkspace(ws).withObjects(
-																	       Arrays.asList(new ObjectSaveData().withType(DomainSearchTask.domainAlignmentsWsType)
-																			     .withName(id + ".aln").withData(new UObject(alnRes))
-																			     .withProvenance(Arrays.asList(new ProvenanceAction().withDescription(
-																												  "Domain alignments for genome " + genomeRef)
-																							   .withService(KBaseGeneFamiliesServer.SERVICE_REGISTERED_NAME)
-																							   .withServiceVer(KBaseGeneFamiliesServer.SERVICE_VERSION)
-																							   .withMethod(serviceMethod)
-																							   .withMethodParams(Arrays.asList(new UObject(inputData)))))))).get(0));
-	annRes.setAlignmentsRef(alignmentsRef);
 	ObjectSaveData data = new ObjectSaveData().withData(new UObject(annRes))
 	    .withType(DomainSearchTask.domainAnnotationWsType)
 	    .withProvenance(Arrays.asList(new ProvenanceAction()
-					  .withDescription("Domain annotation was constructed using rps-blast program")
+					  .withDescription("Domain annotation was calculated with rps-blast/hmmer")
 					  .withService(KBaseGeneFamiliesServer.SERVICE_REGISTERED_NAME)
 					  .withServiceVer(KBaseGeneFamiliesServer.SERVICE_VERSION)
 					  .withMethod(serviceMethod)
@@ -77,7 +64,6 @@ public class SearchDomainsBuilder extends DefaultTaskBuilder<SearchDomainsParams
 	} catch (NumberFormatException ex) {
 	    data.withName(id);
 	}
-	return DomainSearchTask.getRefFromObjectInfo(storage.saveObjects(token, new SaveObjectsParams().withWorkspace(ws).withObjects(
-																      Arrays.asList(data))).get(0));
+	return DomainSearchTask.getRefFromObjectInfo(storage.saveObjects(token, new SaveObjectsParams().withWorkspace(ws).withObjects(Arrays.asList(data))).get(0));
     }
 }

--- a/src/us/kbase/kbasegenefamilies/test/ClientTest.java
+++ b/src/us/kbase/kbasegenefamilies/test/ClientTest.java
@@ -1,0 +1,181 @@
+package us.kbase.kbasegenefamilies.test;
+
+import java.io.*;
+import java.util.*;
+import java.net.URL;
+
+import org.junit.Test;
+import static junit.framework.Assert.*;
+
+import org.strbio.IO;
+import org.strbio.util.*;
+import com.fasterxml.jackson.databind.*;
+
+import us.kbase.auth.AuthService;
+import us.kbase.auth.AuthToken;
+import us.kbase.common.service.*;
+import us.kbase.workspace.*;
+import us.kbase.kbasegenomes.*;
+import us.kbase.kbasegenefamilies.*;
+import us.kbase.userandjobstate.UserAndJobStateClient;
+
+/**
+   Tests for annotating genome (DvH) via the client
+*/
+public class ClientTest {
+    private static final String wsUrl = "https://kbase.us/services/ws/";
+    private static final String gfUrl = "http://localhost:8123";
+    private static final String genomeWsName = "KBasePublicGenomesV4";
+    private static final String domainWsName = "KBasePublicGeneDomains";
+    private static final String privateWsName = "jmc:gene_domains_test";
+    private static final String domainAnnotationType = "KBaseGeneFamilies.DomainAnnotation-1.0";
+    private static final String dvID = "kb|g.3562";
+    private static final String smartRef = domainWsName+"/SMART-only";
+    private static final String allLibsRef = domainWsName+"/All";
+
+    /**
+       check that we can read DvH genome from private WS
+    */
+    @Test public void getDV() throws Exception {
+	Genome genome = null;
+	
+	WorkspaceClient wc = createWsClient(getDevToken());
+	genome = wc.getObjects(Arrays.asList(new ObjectIdentity().withRef(privateWsName+"/"+dvID))).get(0).getData().asClassInstance(Genome.class);
+	
+	System.out.println(genome.getScientificName());
+	assertEquals(genome.getScientificName(), "Desulfovibrio vulgaris str. Hildenborough");
+    }
+
+    /**
+       check that we can read version
+    */
+    @Test public void getVersion() throws Exception {
+	KBaseGeneFamiliesClient gf = new KBaseGeneFamiliesClient(new URL(gfUrl));
+	gf.setIsInsecureHttpConnectionAllowed(true);
+	String version = gf.version();
+	System.out.println("service version is "+version);
+	assertNotNull(version);
+    }
+
+    /**
+       Check that we can annotate DvH with SMART.  This is
+       fairly fast.
+    */
+    @Test
+    public void searchDVPSSM() throws Exception {
+
+	AuthToken token = getDevToken();
+
+	String genomeRef = privateWsName+"/"+dvID;
+
+	KBaseGeneFamiliesClient gf = new KBaseGeneFamiliesClient(new URL(gfUrl), token);
+	gf.setIsInsecureHttpConnectionAllowed(true);
+	String jobId = gf.searchDomains(new SearchDomainsParams()
+					.withDmsRef(smartRef)
+					.withGenome(genomeRef)
+					.withOutWorkspace(privateWsName)
+					.withOutResultId("DvH-SMART"));
+	UserAndJobStateClient jscl = new UserAndJobStateClient(new URL("https://kbase.us/services/userandjobstate/"), token);
+	jscl.setAllSSLCertificatesTrusted(true);
+	jscl.setIsInsecureHttpConnectionAllowed(true);
+	for (int iter = 0; ; iter++) {
+	    Tuple7<String, String, String, Long, String, Long, Long> data = jscl.getJobStatus(jobId);
+	    String status = data.getE3();
+	    Long complete = data.getE6();
+	    Long wasError = data.getE7();
+	    System.out.println("Status (" + iter + "): " + status);
+	    if (complete == 1L) {
+		if (wasError == 0L) {
+		    String rv = jscl.getResults(jobId).getWorkspaceids().get(0);
+		    System.out.println("Annotation reference: " + rv);
+		}
+		else {
+		    System.out.println("Detailed error:");
+		    System.out.println(jscl.getDetailedError(jobId));
+		}
+		break;
+	    }
+	    Thread.sleep(12000);
+	}
+    }
+
+    /**
+       Check that we can annotate DvH with all domains.  This
+       should take about an hour.
+    @Test
+    */
+    public void searchDVAll() throws Exception {
+
+	AuthToken token = getDevToken();
+
+	String genomeRef = privateWsName+"/"+dvID;
+
+	KBaseGeneFamiliesClient gf = new KBaseGeneFamiliesClient(new URL(gfUrl), token);
+	gf.setIsInsecureHttpConnectionAllowed(true);
+	String jobId = gf.searchDomains(new SearchDomainsParams()
+					.withDmsRef(allLibsRef)
+					.withGenome(genomeRef)
+					.withOutWorkspace(privateWsName)
+					.withOutResultId("DvH-AllDomains"));
+	UserAndJobStateClient jscl = new UserAndJobStateClient(new URL("https://kbase.us/services/userandjobstate/"), token);
+	jscl.setAllSSLCertificatesTrusted(true);
+	jscl.setIsInsecureHttpConnectionAllowed(true);
+	for (int iter = 0; ; iter++) {
+	    Tuple7<String, String, String, Long, String, Long, Long> data = jscl.getJobStatus(jobId);
+	    String status = data.getE3();
+	    Long complete = data.getE6();
+	    Long wasError = data.getE7();
+	    System.out.println("Status (" + iter + "): " + status);
+	    if (complete == 1L) {
+		if (wasError == 0L) {
+		    String rv = jscl.getResults(jobId).getWorkspaceids().get(0);
+		    System.out.println("Annotation reference: " + rv);
+		}
+		else {
+		    System.out.println("Detailed error:");
+		    System.out.println(jscl.getDetailedError(jobId));
+		}
+		break;
+	    }
+	    Thread.sleep(12000);
+	}
+    }
+
+    /**
+       creates a workspace client; if token is null, client can
+       only read public workspaces
+    */
+    public static WorkspaceClient createWsClient(AuthToken token) throws Exception {
+	WorkspaceClient rv = null;
+	if (token==null)
+	    rv = new WorkspaceClient(new URL(wsUrl));
+	else
+	    rv = new WorkspaceClient(new URL(wsUrl),token);
+	rv.setAuthAllowedForHttp(true);
+	return rv;
+    }
+
+    /**
+       gets the auth token out of the properties file.  To create
+       it on your dev instance, do:
+       <pre>
+       kbase-login (your user name)
+       kbase-whoami -t
+       </pre>
+       Take the resulting text (starting with "un=") and put it in
+       the auth.properties file, as auth.token.  Replace the text
+       in the file that says "paste token here" with your token.
+    */
+    public static AuthToken getDevToken() throws Exception {
+	Properties prop = new Properties();
+	try {
+	    prop.load(EColiTest.class.getClassLoader().getResourceAsStream("auth.properties"));
+	}
+	catch (IOException e) {
+	}
+	catch (SecurityException e) {
+	}
+	String value = prop.getProperty("auth.token", null);
+	return new AuthToken(value);
+    }
+}

--- a/src/us/kbase/kbasegenefamilies/test/DomainSearchTester.java
+++ b/src/us/kbase/kbasegenefamilies/test/DomainSearchTester.java
@@ -69,7 +69,8 @@ public class DomainSearchTester {
 	//findMSA(client);
 	testSpeed2(client);
     }
-	
+
+    /*
     private static void runDomainSearchLocally(WorkspaceClient client, String token, File tempDir) throws Exception {
 	String genomeRef = wsName + "/Burkholderia_YI23_uid81081.genome";
 	String outId = "TempDomains";
@@ -113,7 +114,9 @@ public class DomainSearchTester {
 	}
 	pw.println("-= Domains =-");
 	for (DomainClusterStat dcs : dcsr.getDomainClusterStatistics().values()) {
-	    pw.println("Domain " /* + dcs.getDomainModelRef() + ", "*/ + dcs.getName() + ": g=" + dcs.getGenomes() + ", " +
+	    pw.println("Domain "
+	    //  + dcs.getDomainModelRef() + ", "
+	    + dcs.getName() + ": g=" + dcs.getGenomes() + ", " +
 		       "f=" + dcs.getFeatures() + ", d=" + dcs.getDomains());
 	}
 	pw.close();
@@ -149,6 +152,7 @@ public class DomainSearchTester {
 	    Thread.sleep(12000);
 	}
     }
+*/
 	
     private static String runDomainSearchOnly(WorkspaceClient client, String token) throws Exception {
 	KBaseGeneFamiliesClient gf = new KBaseGeneFamiliesClient(new URL(geneFamiliesUrl), new AuthToken(token));
@@ -182,7 +186,8 @@ public class DomainSearchTester {
 	}
 	return ret;
     }
-	
+
+/*
     private static void runDomainClustersExtension(WorkspaceClient client, String token, String annotRef) throws Exception {
 	KBaseGeneFamiliesClient gf = new KBaseGeneFamiliesClient(new URL(geneFamiliesUrl), new AuthToken(token));
 	gf.setIsInsecureHttpConnectionAllowed(true);
@@ -213,6 +218,7 @@ public class DomainSearchTester {
 	    Thread.sleep(12000);
 	}
     }
+*/
 	
     private static void findMSA(WorkspaceClient wc) throws Exception {
 	String dcsrRef = domainWsName + "/" + defaultDCSRObjectName;

--- a/src/us/kbase/kbasegenefamilies/test/EColiTest.java
+++ b/src/us/kbase/kbasegenefamilies/test/EColiTest.java
@@ -19,7 +19,7 @@ import us.kbase.kbasegenomes.*;
 import us.kbase.kbasegenefamilies.*;
 
 /**
-   Tests for setting up sample db and annotating E. coli
+   Tests for setting up sample db and annotating E. coli locally
 */
 public class EColiTest {
     private static final String wsUrl = "https://kbase.us/services/ws/";
@@ -107,8 +107,8 @@ public class EColiTest {
     /**
        Check that we can annotate E. coli with TIGRFAMs.  Takes ~12 min
        on a 2-CPU Magellan instance.
-    */
     @Test
+    */
 	public void searchEColiHMM() throws Exception {
 
 	AuthToken token = getDevToken();
@@ -133,8 +133,8 @@ public class EColiTest {
     /**
        Check that we can annotate E. coli with all domain libraries.
        Takes ~65 min on a 2-CPU Magellan instance.
-    */
     @Test
+    */
 	public void searchEColiAll() throws Exception {
 
 	AuthToken token = getDevToken();


### PR DESCRIPTION
Please merge these changes, then re-register the typespec.  I changed the API to store
in DomainAnnotation a reference to the set of models that was used.  (I also got rid of alignments
altogether, rather than making the optional; this was confusing since we don't currently support it.)