### PR TITLE
Fixed DomainModelLibPreparation to create any needed workspaces before

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,7 +30,7 @@
     <include name="jackson/jackson-annotations-2.2.3.jar"/>
     <include name="jackson/jackson-core-2.2.3.jar"/>
     <include name="jackson/jackson-databind-2.2.3.jar"/>
-    <include name="kbase/shock/shock-client-0.0.7.jar" />
+    <include name="kbase/shock/shock-client-0.0.8.jar" />
     <include name="kbase/kbase-common-temp.jar" />
     <include name="kbase/workspace/WorkspaceClient-0.2.0.jar"/>
     <include name="kbase/genomes/kbase-genomes-20140411.jar"/>

--- a/src/us/kbase/kbasegenefamilies/prepare/DomainModelLibPreparation.java
+++ b/src/us/kbase/kbasegenefamilies/prepare/DomainModelLibPreparation.java
@@ -19,10 +19,12 @@ import us.kbase.common.taskqueue.TaskQueueConfig;
 
 public class DomainModelLibPreparation {
     private static final String domainWsName = "KBasePublicGeneDomains";
-    private static final String domainLibraryType = "KBaseGeneFamilies.DomainLibrary-1.0";
-    private static final String domainModelSetType = "KBaseGeneFamilies.DomainModelSet-1.0";
+    private static final String domainLibraryType = "KBaseGeneFamilies.DomainLibrary";
+    private static final String domainModelSetType = "KBaseGeneFamilies.DomainModelSet";
 
     public static void main(String[] args) throws Exception {
+	checkOrCreateWorkspace();
+	
 	parseDomainLibrary("COGs-CDD-3.12",
 			   "ftp://ftp.ncbi.nih.gov/pub/mmdb/cdd/",
 			   "/kb/dev_container/modules/gene_families/data/db/Cog",
@@ -97,6 +99,21 @@ public class DomainModelLibPreparation {
 	
 	makeDomainModelSet("All",
 			   libraries);
+    }
+
+    /**
+       make the public workspace, if it does not already exist on this
+       version of the service
+    */
+    private static void checkOrCreateWorkspace() throws Exception {
+	WorkspaceClient wc = createWsClient(getDevToken());
+	try {
+	    wc.getWorkspaceInfo(new WorkspaceIdentity().withWorkspace(domainWsName));
+	}
+	catch (Exception e) {
+	    System.err.println(e.getMessage());
+	    wc.createWorkspace(new CreateWorkspaceParams().withGlobalread("r").withWorkspace(domainWsName));
+	}
     }
 
     /**

--- a/src/us/kbase/kbasegenefamilies/test/ClientTest.java
+++ b/src/us/kbase/kbasegenefamilies/test/ClientTest.java
@@ -52,8 +52,8 @@ public class ClientTest {
 
     /**
        check that we can read DvH genome from private WS
-    */
     @Test
+    */
     public void getDV() throws Exception {
 	Genome genome = null;
 	
@@ -67,7 +67,8 @@ public class ClientTest {
     /**
        check that we can read version
     */
-    @Test public void getVersion() throws Exception {
+    @Test
+	public void getVersion() throws Exception {
 	KBaseGeneFamiliesClient gf = createGfClient(null);
 	String version = gf.version();
 	System.out.println("service version is "+version);
@@ -77,8 +78,8 @@ public class ClientTest {
     /**
        Check that we can annotate DvH with SMART.  This is
        fairly fast.
-    */
     @Test
+    */
     public void searchDVPSSM() throws Exception {
 	AuthToken token = getDevToken();
 


### PR DESCRIPTION
trying to write to them.  Bumped java shock lib requirement to 0.0.8,
in order to work with CI shock instance