### PR TITLE
update hmmer binary location

### DIFF
--- a/download_3rd_party_bins.sh
+++ b/download_3rd_party_bins.sh
@@ -21,7 +21,7 @@ if [[ "$unamestr" == 'Linux' ]]; then
 	########### HMMER #############
 	if [ ! -f ../bin/hmmscan.linux ]; then
 		echo "Downloading hmmer..."
-		curl -o hmmer.tar.gz 'ftp://selab.janelia.org/pub/software/hmmer3/3.1b1/hmmer-3.1b1-linux-intel-x86_64.tar.gz'
+		curl -o hmmer.tar.gz 'http://eddylab.org/software/hmmer3/3.1b1/hmmer-3.1b1-linux-intel-x86_64.tar.gz'
 		tar -zxvf hmmer.tar.gz hmmer-3.1b1-linux-intel-x86_64/binaries/hmmscan hmmer-3.1b1-linux-intel-x86_64/binaries/hmmpress
 		mv ./hmmer-3.1b1-linux-intel-x86_64/binaries/hmmscan ../bin/hmmscan.linux
 		mv ./hmmer-3.1b1-linux-intel-x86_64/binaries/hmmpress ../bin/hmmpress.linux
@@ -45,7 +45,7 @@ elif [[ "$unamestr" == 'Darwin' ]]; then
 	########### HMMER #############
 	if [ ! -f ../bin/hmmscan.macosx ]; then
 		echo "Downloading hmmer..."
-		curl -o hmmer.tar.gz 'ftp://selab.janelia.org/pub/software/hmmer3/3.1b1/hmmer-3.1b1-macosx-intel.tar.gz'
+		curl -o hmmer.tar.gz 'http://eddylab.org/software/hmmer3/3.1b1/hmmer-3.1b1-macosx-intel.tar.gz'
 		tar -zxvf hmmer.tar.gz hmmer-3.1b1-macosx-intel/binaries/hmmscan hmmer-3.1b1-macosx-intel/binaries/hmmpress
 		mv ./hmmer-3.1b1-macosx-intel/binaries/hmmscan ../bin/hmmscan.macosx
 		mv ./hmmer-3.1b1-macosx-intel/binaries/hmmpress ../bin/hmmpress.macosx


### PR DESCRIPTION
Fixes this bug:

Date: Fri, 22 Jan 2016 13:56:10 -0800
From kkeller@lbl.gov  Fri Jan 22 13:56:19 2016
From: Keith Keller <kkeller@lbl.gov>
To: John-Marc Chandonia <JMChandonia@lbl.gov>
Subject: selab.janelia down

Hey John-Marc,

During the last deploy of gene_families on ci, the install tried to
contact selab.janelia.org and failed.  It's not clear whether this is
a temporary or permanent change at Janelia.  Have you heard one way or
the other what their status might be?

I'm going to disable the gene_families deploy for now, so that the
Jenkins build can complete.

--keith
